### PR TITLE
Fix logging Fire handling missing node field

### DIFF
--- a/packages/logging/logging.go
+++ b/packages/logging/logging.go
@@ -59,11 +59,16 @@ func (l *Logging) Fire(entry *logrus.Entry) error {
 		level = rpc.LogLevel_INFO
 	}
 
+	node, ok := entry.Data["node"].(string)
+	if !ok {
+		node = ""
+	}
+
 	// Create log request
 	req := &rpc.LogsRequest{
 		Level:   level,
 		Message: entry.Message,
-		Node:    entry.Data["node"].(string),
+		Node:    node,
 	}
 
 	return l.Broadcast(req)

--- a/tests/unit/logging_test.go
+++ b/tests/unit/logging_test.go
@@ -1,0 +1,34 @@
+package unit
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/syleron/pulseha/packages/logging"
+	"github.com/syleron/pulseha/rpc"
+)
+
+// TestLoggingFireMissingNode verifies that Fire handles entries without the
+// "node" field gracefully and defaults to an empty string.
+func TestLoggingFireMissingNode(t *testing.T) {
+	var req *rpc.LogsRequest
+	logger, _ := logging.NewLogger(func(r *rpc.LogsRequest) error {
+		req = r
+		return nil
+	})
+
+	entry := &logrus.Entry{
+		Logger:  logrus.New(),
+		Level:   logrus.InfoLevel,
+		Message: "test message",
+		Data:    logrus.Fields{},
+	}
+
+	assert.NotPanics(t, func() {
+		err := logger.Fire(entry)
+		assert.NoError(t, err)
+	})
+	assert.NotNil(t, req)
+	assert.Equal(t, "", req.Node)
+}


### PR DESCRIPTION
## Summary
- handle missing node field in logging hook
- add regression test for missing node field

## Testing
- `go vet ./...` *(fails: missing go.sum entries)*
- `go test ./...` *(fails: missing go.sum entries)*
- `govulncheck ./...` *(fails: command not found)*