### PR TITLE
Handle missing interface in SendGARP

### DIFF
--- a/internal/membership/member.go
+++ b/internal/membership/member.go
@@ -198,8 +198,8 @@ func (m *Member) bringUpIPsLocally(iface string, ips []string) error {
 		}
 
 		// Send gratuitous ARP to update network
-		if !network.SendGARP(iface, ip) {
-			m.logger.Warnf("Failed to send GARP for IP %s on interface %s", ip, iface)
+		if err := network.SendGARP(iface, ip); err != nil {
+			m.logger.Warnf("Failed to send GARP for IP %s on interface %s: %v", ip, iface, err)
 			// Don't return error as the IP is still up
 		}
 

--- a/packages/network/network.go
+++ b/packages/network/network.go
@@ -49,24 +49,24 @@ type ICMPv6NeighborSolicitation struct {
 Send Gratuitous ARP to automagically tell the router who has the new floating IP
 NOTE: This function assumes the OS is LINUX and has "arping" installed.
 */
-func SendGARP(iface, ip string) bool {
+func SendGARP(iface, ip string) error {
 	exists, _ := InterfaceExist(iface)
 	if !exists {
-		log.Error("Unable to GARP as the network interface does not exist! Closing..")
-		os.Exit(1)
+		log.Error("Unable to GARP as the network interface does not exist")
+		return errors.New("network interface does not exist")
 	}
 	cidrIP, _, err := net.ParseCIDR(ip)
 	if err != nil {
 		log.Error("failed to GARP. Cannot parse CIDR")
-		return false
+		return err
 	}
 	log.Debug("Sending gratuitous arp for " + cidrIP.String() + " on interface " + iface)
 	_, err = utils.Execute("arping", "-U", "-c", "5", "-I", iface, cidrIP.String())
 	if err != nil {
 		log.Error("failed to GARP. " + err.Error())
-		return false
+		return err
 	}
-	return true
+	return nil
 }
 
 /*

--- a/packages/network/network_test.go
+++ b/packages/network/network_test.go
@@ -44,3 +44,15 @@ func TestICMPv4(t *testing.T) {
 		t.Skip("Skipping ICMP test due to environment constraints")
 	}
 }
+
+func TestSendGARPNoExit(t *testing.T) {
+	// Skip in CI environments as it relies on host network information
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping GARP test in CI environment")
+	}
+
+	err := SendGARP("fakeiface0", "192.0.2.1/24")
+	if err == nil {
+		t.Fatalf("expected error for non-existent interface")
+	}
+}


### PR DESCRIPTION
## Summary
- stop exiting the program when a GARP interface is missing and return an error instead
- log the error in membership when GARP fails
- test that SendGARP returns an error for nonexistent interfaces

## Testing
- `go vet ./...` *(fails: missing go.sum entries)*
- `make test` *(fails: missing go.sum entries)*