### PR TITLE
Update config file permissions to 0600

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ The configuration file is stored in `~/.pulseha/config.json` by default. Key con
   "floating_ip_groups": {},
   "nodes": {},
   "plugins": {}
-}
-```
+ }
+ ```
+
+> **Security Note:** Configuration files are now written with permissions `0600` instead of `0644`. Existing installations should update the permissions of `~/.pulseha/config.json` accordingly to restrict access to the owner.
 
 ## Usage
 

--- a/packages/config/config.go
+++ b/packages/config/config.go
@@ -306,7 +306,7 @@ func (c *Config) SaveDefaultLocalConfig() error {
 	}
 
 	// Save back to file
-	if err := ioutil.WriteFile(CONFIG_LOCATION, configJSON, 0644); err != nil {
+	if err := ioutil.WriteFile(CONFIG_LOCATION, configJSON, 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %v", err)
 	}
 
@@ -549,7 +549,7 @@ func (c *Config) Save() error {
 		return fmt.Errorf("failed to marshal config: %v", err)
 	}
 
-	if err := ioutil.WriteFile(CONFIG_LOCATION, data, 0644); err != nil {
+	if err := ioutil.WriteFile(CONFIG_LOCATION, data, 0600); err != nil {
 		return fmt.Errorf("failed to write config: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- ensure configuration files are written with permissions `0600`
- document new configuration file permissions in README

## Testing
- `go vet ./...` *(fails: missing go.sum entry for modules)*
- `go test ./...` *(fails: missing go.sum entry for modules)*