### PR TITLE
Fix log file permissions

### DIFF
--- a/cmd/pulseha/main.go
+++ b/cmd/pulseha/main.go
@@ -209,7 +209,10 @@ func initQuorumFlags(rootCmd *cobra.Command) {
 
 func setupLogging(cfg *config.Config, logger *log.Logger) error {
 	// Setup file logging
-	logFile, err := os.OpenFile(cfg.Pulse.LogFileLocation, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
+	// Restrict permissions so that only the owner can modify the log and
+	// the group can read it. This avoids exposing potentially sensitive
+	// log output to the world.
+	logFile, err := os.OpenFile(cfg.Pulse.LogFileLocation, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0640)
 	if err != nil {
 		return fmt.Errorf("failed to open log file: %v", err)
 	}


### PR DESCRIPTION
## Summary
- use 0640 when creating the log file in the PulseHA daemon
- document why the permissions are restrictive

## Testing
- `go vet ./...` *(fails: missing go.sum entries)*
- `go test ./...` *(fails: missing go.sum entries)*