### PR TITLE
Improve certificate file creation security

### DIFF
--- a/packages/security/certs.go
+++ b/packages/security/certs.go
@@ -48,20 +48,46 @@ func GenerateCertificates(hostname string) error {
 	}
 
 	// Save CA certificate
-	caCertFile, err := os.Create(filepath.Join(CertDir, "ca.crt"))
+	caCertPath := filepath.Join(CertDir, "ca.crt")
+	caCertTmpPath := caCertPath + ".tmp"
+	caCertFile, err := os.OpenFile(caCertTmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to create CA certificate file: %v", err)
 	}
-	pem.Encode(caCertFile, &pem.Block{Type: "CERTIFICATE", Bytes: caBytes})
-	caCertFile.Close()
+	if err := pem.Encode(caCertFile, &pem.Block{Type: "CERTIFICATE", Bytes: caBytes}); err != nil {
+		caCertFile.Close()
+		os.Remove(caCertTmpPath)
+		return fmt.Errorf("failed to write CA certificate: %v", err)
+	}
+	if err := caCertFile.Close(); err != nil {
+		os.Remove(caCertTmpPath)
+		return fmt.Errorf("failed to close CA certificate file: %v", err)
+	}
+	if err := os.Rename(caCertTmpPath, caCertPath); err != nil {
+		os.Remove(caCertTmpPath)
+		return fmt.Errorf("failed to atomically create CA certificate file: %v", err)
+	}
 
 	// Save CA private key
-	caKeyFile, err := os.Create(filepath.Join(CertDir, "ca.key"))
+	caKeyPath := filepath.Join(CertDir, "ca.key")
+	caKeyTmpPath := caKeyPath + ".tmp"
+	caKeyFile, err := os.OpenFile(caKeyTmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create CA key file: %v", err)
 	}
-	pem.Encode(caKeyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(caKey)})
-	caKeyFile.Close()
+	if err := pem.Encode(caKeyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(caKey)}); err != nil {
+		caKeyFile.Close()
+		os.Remove(caKeyTmpPath)
+		return fmt.Errorf("failed to write CA key: %v", err)
+	}
+	if err := caKeyFile.Close(); err != nil {
+		os.Remove(caKeyTmpPath)
+		return fmt.Errorf("failed to close CA key file: %v", err)
+	}
+	if err := os.Rename(caKeyTmpPath, caKeyPath); err != nil {
+		os.Remove(caKeyTmpPath)
+		return fmt.Errorf("failed to atomically create CA key file: %v", err)
+	}
 
 	// Generate node key pair
 	nodeKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -92,20 +118,46 @@ func GenerateCertificates(hostname string) error {
 	}
 
 	// Save node certificate
-	nodeCertFile, err := os.Create(filepath.Join(CertDir, "pulseha.crt"))
+	nodeCertPath := filepath.Join(CertDir, "pulseha.crt")
+	nodeCertTmpPath := nodeCertPath + ".tmp"
+	nodeCertFile, err := os.OpenFile(nodeCertTmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to create node certificate file: %v", err)
 	}
-	pem.Encode(nodeCertFile, &pem.Block{Type: "CERTIFICATE", Bytes: nodeCertBytes})
-	nodeCertFile.Close()
+	if err := pem.Encode(nodeCertFile, &pem.Block{Type: "CERTIFICATE", Bytes: nodeCertBytes}); err != nil {
+		nodeCertFile.Close()
+		os.Remove(nodeCertTmpPath)
+		return fmt.Errorf("failed to write node certificate: %v", err)
+	}
+	if err := nodeCertFile.Close(); err != nil {
+		os.Remove(nodeCertTmpPath)
+		return fmt.Errorf("failed to close node certificate file: %v", err)
+	}
+	if err := os.Rename(nodeCertTmpPath, nodeCertPath); err != nil {
+		os.Remove(nodeCertTmpPath)
+		return fmt.Errorf("failed to atomically create node certificate file: %v", err)
+	}
 
 	// Save node private key
-	nodeKeyFile, err := os.Create(filepath.Join(CertDir, "pulseha.key"))
+	nodeKeyPath := filepath.Join(CertDir, "pulseha.key")
+	nodeKeyTmpPath := nodeKeyPath + ".tmp"
+	nodeKeyFile, err := os.OpenFile(nodeKeyTmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create node key file: %v", err)
 	}
-	pem.Encode(nodeKeyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(nodeKey)})
-	nodeKeyFile.Close()
+	if err := pem.Encode(nodeKeyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(nodeKey)}); err != nil {
+		nodeKeyFile.Close()
+		os.Remove(nodeKeyTmpPath)
+		return fmt.Errorf("failed to write node key: %v", err)
+	}
+	if err := nodeKeyFile.Close(); err != nil {
+		os.Remove(nodeKeyTmpPath)
+		return fmt.Errorf("failed to close node key file: %v", err)
+	}
+	if err := os.Rename(nodeKeyTmpPath, nodeKeyPath); err != nil {
+		os.Remove(nodeKeyTmpPath)
+		return fmt.Errorf("failed to atomically create node key file: %v", err)
+	}
 
 	return nil
 }

--- a/tests/unit/certs_test.go
+++ b/tests/unit/certs_test.go
@@ -1,0 +1,24 @@
+package unit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/syleron/pulseha/packages/security"
+)
+
+func TestGenerateCertificatesCreatesKeyWith0600Mode(t *testing.T) {
+	dir := t.TempDir()
+	orig := security.CertDir
+	security.CertDir = dir
+	defer func() { security.CertDir = orig }()
+
+	err := security.GenerateCertificates("localhost")
+	assert.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(dir, "pulseha.key"))
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}


### PR DESCRIPTION
## Summary
- atomically create TLS certificate and key files
- ensure `pulseha.key` is written with `0600` permissions
- test private key permissions

## Testing
- `go test ./...` *(fails: missing go.sum entries)*
- `go vet ./...` *(fails: missing go.sum entries)*