### PR TITLE
Handle pulseha missing config error

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -161,22 +161,20 @@ func (s *Server) Start() error {
 		s.logger.Warn("Quorum handler is nil, quorum RPC methods will not be available")
 	}
 
-	// Start the health checker
+	// Start the health checker (may no-op if already running)
 	s.startHealthChecker()
 
-	// Start the IP monitor
-	if err := s.ipMonitor.Start(); err != nil {
-		s.logger.Errorf("Failed to start IP monitor: %v", err)
-		// Continue anyway, as this is not critical
-	}
-
-	// If cluster is not yet configured, a watcher below will start it when ready
-
-	// Only start health checker if we have a configured cluster
+	// Only start IP monitor and ensure health checker when a cluster is configured
 	if s.config.ClusterCheck() {
+		// Ensure health checker is running with current config
 		s.startHealthChecker()
+		// Start IP monitor now that cluster information is available
+		if err := s.ipMonitor.Start(); err != nil {
+			s.logger.Errorf("Failed to start IP monitor: %v", err)
+			// Continue anyway, as this is not critical
+		}
 	} else {
-		s.logger.Debug("No cluster configured, health checker will start when cluster is created")
+		s.logger.Debug("No cluster configured; deferring IP monitor start until cluster creation")
 		// Start a configuration watcher to detect when we join a cluster and start the cluster RPC server
 		go s.watchForClusterJoin()
 	}
@@ -212,6 +210,13 @@ func (s *Server) watchForClusterJoin() {
 
 				// Start the health checker
 				s.startHealthChecker()
+
+				// Start IP monitor now that cluster configuration is present
+				if s.ipMonitor != nil {
+					if err := s.ipMonitor.Start(); err != nil {
+						s.logger.Errorf("Failed to start IP monitor after joining cluster: %v", err)
+					}
+				}
 
 				// Start cluster RPC server if not already started
 				if s.grpcServer == nil {


### PR DESCRIPTION
Defer IP monitor startup until a cluster is configured to prevent errors when starting without a config.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab5d9df2-29b2-476e-a498-cea1af531646">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab5d9df2-29b2-476e-a498-cea1af531646">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

