### PR TITLE
Fail-fast on maintenance demote errors and protect CLI socket from steal

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -178,11 +178,22 @@ func (s *Server) Start() error {
 	s.cliSocketPath = socketPath
 	s.logger.Debug("Starting CLI gRPC server", "socket", socketPath)
 
-	// Ensure parent directory exists and remove any stale socket file
+	// Ensure parent directory exists
 	if err := os.MkdirAll(filepath.Dir(socketPath), 0750); err != nil {
 		return fmt.Errorf("failed to create socket directory %s: %v", filepath.Dir(socketPath), err)
 	}
-	os.Remove(socketPath)
+	// Only remove the existing socket if it is stale. If another daemon is already
+	// listening on it, refuse to start rather than silently steal its socket.
+	if _, statErr := os.Stat(socketPath); statErr == nil {
+		conn, dialErr := net.DialTimeout("unix", socketPath, 200*time.Millisecond)
+		if dialErr == nil {
+			conn.Close()
+			return fmt.Errorf("another process is already listening on %s; refusing to start", socketPath)
+		}
+		if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove stale socket %s: %v", socketPath, err)
+		}
+	}
 
 	s.cliServer = grpc.NewServer()
 	// Register both CLI and Server services on the local listener so local operations (e.g., ConfigSync) work pre-cluster
@@ -3992,11 +4003,23 @@ func (s *Server) setMaintenanceLocal(ctx context.Context, localID string, enable
 			return &rpc.SetMaintenanceResponse{Success: false, Message: "cannot enter maintenance: at least one other node must remain available"}, nil
 		}
 
-		// Demote first if active so the cluster elects a new active node
+		// Demote first if active so the cluster elects a new active node.
+		// Abort maintenance if demotion fails — otherwise the node would be marked
+		// maintenance while still holding active IPs, leaving the cluster in a split state.
 		if currentStatus == membership.StatusActive || currentStatus == membership.StatusPartialActive {
 			s.logger.Info("Maintenance: local node is active — triggering failover before entering maintenance")
-			if _, err := s.MakePassive(ctx, &rpc.MakePassiveRequest{NodeId: localID}); err != nil {
-				s.logger.Warn("Maintenance: MakePassive RPC error (continuing anyway)", "error", err)
+			resp, err := s.MakePassive(ctx, &rpc.MakePassiveRequest{NodeId: localID})
+			if err != nil {
+				s.logger.Error("Maintenance: MakePassive RPC error; aborting maintenance entry", "error", err)
+				return &rpc.SetMaintenanceResponse{Success: false, Message: "failed to demote node before maintenance: " + err.Error()}, nil
+			}
+			if resp == nil || !resp.Success {
+				msg := "demotion reported failure"
+				if resp != nil && resp.Message != "" {
+					msg = resp.Message
+				}
+				s.logger.Error("Maintenance: MakePassive returned failure; aborting maintenance entry", "message", msg)
+				return &rpc.SetMaintenanceResponse{Success: false, Message: "failed to demote node before maintenance: " + msg}, nil
 			}
 		}
 


### PR DESCRIPTION
## Summary

Two follow-up fixes for the maintenance mode and Unix socket work introduced in #217 (some of the original review items have already been addressed by #218 / #220 — this PR covers what's still outstanding).

### 1. `setMaintenanceLocal`: fail-fast when demotion fails

When entering maintenance on a currently-active node, `setMaintenanceLocal` calls `MakePassive` to demote first. The previous code only checked the transport error (and logged it at Warn, then continued), and never inspected `resp.Success` at all. Two failure modes were swallowed:

- Transport error → log + continue → node marked maintenance with IPs still bound.
- `MakePassive` returns `(resp{Success:false, Message:\"…\"}, nil)` (the project's standard \"soft failure\" pattern) → completely ignored → same outcome.

In either case the cluster ends up with no eligible active node holding the IPs that this node still actually has up. The fix aborts maintenance entry and surfaces the demotion error to the operator.

### 2. `Server.Start`: dial-probe before removing the CLI socket

The CLI socket setup unconditionally `os.Remove(socketPath)`-ed any pre-existing socket before `net.Listen`. If a pulseha daemon is already running on the same host (intentionally or accidentally), the second daemon silently yanks the socket out from under the first, and `pulsectl` calls then land on the new (probably broken) instance.

New behaviour: if the socket exists, try to dial it with a 200 ms timeout. If the dial succeeds, refuse to start. If the dial fails, the socket is stale and gets removed as before.

## Out of scope

- **Epoch increment in maintenance broadcasts (`GetClusterEpoch()+1`)** — this is the established codebase pattern used in ~10 other state-change paths. Worth a separate design discussion; not a one-off fix.
- **`ReadConfig` returning `(resp, nil)` on marshal failure** — flagged in the original review but it's consistent with every other RPC in this file, so \"fixing\" it in isolation just adds inconsistency.
- **Bootstrap node starting in maintenance** — already handled by #218/#220 via the persistent `Maintenance` flag and the local-node status override in `loadInitialMembers`.

## Test plan

- [x] `go build ./internal/... ./cmd/... ./packages/...` — clean
- [x] `go test ./internal/... ./packages/... ./tests/unit/...` — pass
- [ ] No new unit tests added: `internal/server` has no existing test harness and adding one is out of scope for these targeted fixes. Both changes are small and reviewable by reading.
- [ ] Manual: on a 2-node test cluster, run `pulsectl node maintenance` on the active node and confirm (a) demotion happens before maintenance is recorded, (b) failure to demote leaves the node active rather than half-maintenance.
- [ ] Manual: with one pulseha daemon already running, start a second daemon on the same host and confirm it fails with \"another process is already listening\" rather than stealing the socket.