### PR TITLE
Logs and unknown

### DIFF
--- a/cmd/pulseha/main.go
+++ b/cmd/pulseha/main.go
@@ -254,10 +254,15 @@ func setupLogging(cfg *config.Config, logger *log.Logger) error {
 		writers = append(writers, logFile)
 	}
 
-	// Always add stdout to the list of logging destinations.
-	writers = append(writers, os.Stdout)
+	// Only fall back to stdout if no other destination was configured.
+	// When running under systemd, stdout is captured and forwarded to the
+	// journal/syslog, so adding it alongside a syslog writer causes every
+	// log line to appear twice.
+	if len(writers) == 0 {
+		writers = append(writers, os.Stdout)
+	}
 
-	// Set multi-writer output (stdout + file if enabled)
+	// Set multi-writer output
 	if len(writers) > 1 {
 		mw := io.MultiWriter(writers...)
 		logger.SetOutput(mw)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3257,6 +3257,11 @@ func (s *Server) CreateCluster(ctx context.Context, req *rpc.CreateClusterReques
 		}, nil
 	}
 
+	// Sync the updated config (with LocalNode set) into the member list before adding
+	// members. Without this, the health checker sees LocalNode="" and treats the node
+	// as remote, causing it to be marked Unknown after gRPC checks fail.
+	s.memberList.UpdateConfig(s.config)
+
 	// Add the first member to the member list
 	if err := s.memberList.AddMember(nodeID, hostname, req.BindIp, bindPort); err != nil {
 		s.logger.Error("Failed to add first node to member list", "error", err)
@@ -4200,12 +4205,16 @@ func (s *Server) ResyncNetwork(ctx context.Context, req *rpc.ResyncNetworkReques
 		"final_local_node_id", newLocalNodeID,
 		"final_node_count", len(s.config.Nodes))
 
+	// Always sync the member list's config pointer after replacing s.config.
+	// If we skip this when ClusterCheck is false (e.g. RESYNC before cluster creation),
+	// the member list holds a stale pointer and CreateCluster's LocalNode update becomes
+	// invisible to the health checker, causing the node to be marked Unknown.
+	s.memberList.UpdateConfig(s.config)
+
 	if s.config.ClusterCheck() {
-		// Sync member list with latest config and reload members
+		// Reload members and reconfigure listener for the new config
 		s.logger.Info("RESYNC: Updating member list with new config",
 			"current_member_count", len(s.memberList.MembersSnapshot()))
-
-		s.memberList.UpdateConfig(s.config)
 
 		s.logger.Info("RESYNC: Loading initial members from new config",
 			"config_node_count", len(s.config.Nodes))


### PR DESCRIPTION
Node end up in a unknown status
  Root cause — two bugs combining:
  
  Bug 1 (RESYNC disconnects the config pointer):
  ResyncNetwork (line 4154) creates a fresh *config.Config from disk and assigns it to s.config. But s.memberList.UpdateConfig() was only called inside the if s.config.ClusterCheck() block — which is false when the disk has 0 nodes (i.e.
  before CreateCluster). So after RESYNC, s.config pointed at a new object but memberList.config was left pointing at the old one. The two were permanently out of sync.

  Bug 2 (CreateCluster never notified the member list):
  CreateCluster sets s.config.Pulse.LocalNode = nodeID on the server's config pointer, but since memberList.config was stale (from Bug 1), the health checker called memberList.config.GetLocalNodeUUID(), got "", and concluded cluster check 
  failed. It then treated the node as remote, attempted gRPC health checks against itself, failed them, and after the failure threshold transitioned the node to Unknown.

  The fixes:
  1. server.go RESYNC — moved s.memberList.UpdateConfig(s.config) outside the ClusterCheck() guard so it always runs when s.config is replaced.
  2. server.go CreateCluster — added s.memberList.UpdateConfig(s.config) before AddMember, so the health checker sees LocalNode as soon as the cluster is created.
