### PR TITLE
fix(server): stop Standby depending on which node you ask

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,55 @@
+# PulseHA
+
+The clustering daemon that keeps a set of appliances agreed on which of them is serving
+traffic, and moves floating IP addresses between them when that answer changes.
+
+This glossary covers the vocabulary of **node status** — the words PulseHA publishes about the
+members of a cluster, and which an operator reads on the appliance's High availability page.
+It is deliberately narrow; terms are added as they are pinned down, not in advance.
+
+## Language
+
+**Cluster Mode**:
+Whether the cluster serves its floating IPs from one node or from several — `active-passive` or
+`active-active`. Changeable at runtime, and the meaning of several terms below depends on it.
+_Avoid_: topology, cluster type, failover mode
+
+**Floating IP**:
+An address the cluster moves between nodes, so that it answers wherever the cluster is
+currently serving.
+_Avoid_: VIP, virtual IP, service IP — on a cloud Platform a VIP binds to a Service IP rather
+than to a Floating IP, so these are different things and not synonyms
+
+**Floating IP Group**:
+A named set of Floating IPs, assigned to a named interface on a node, that move together.
+_Avoid_: pool, set, cluster IPs
+
+**Active**:
+Mode-relative, and the one term here that requires knowing the Cluster Mode before it can be
+read. In active-passive: the elected node — the single member the cluster has chosen, whether
+or not it currently holds any address. In active-active: a member holding at least one Floating
+IP.
+_Avoid_: master, primary, leader
+
+**Passive**:
+A member that is healthy and eligible for promotion but is not the elected node. Only exists
+in active-passive.
+_Avoid_: standby, backup, slave, secondary — "standby" in particular means something else
+here, and nearly the opposite
+
+**Standby**:
+A member that is healthy and eligible for promotion and holds no Floating IPs. Reported in
+active-active only, because that is the only mode in which every member's holdings are known
+to every node. See [ADR-0001](./docs/adr/0001-standby-is-active-active-only.md).
+_Avoid_: partial active, partially active, spare, idle
+
+**Maintenance**:
+A member the operator has deliberately excluded from promotion. Reachable and healthy, so
+neither serving nor failed.
+_Avoid_: out of service, drained, disabled, offline
+
+**Unknown**:
+A member that has given no healthy answer — not yet reached, or no longer answering health
+checks. A statement about knowledge of the member, not about a state the member is in.
+_Avoid_: offline, down, dead, unavailable, suspicious — the last two are appliance WebUI
+vocabulary with no PulseHA status behind them

--- a/docs/adr/0001-standby-is-active-active-only.md
+++ b/docs/adr/0001-standby-is-active-active-only.md
@@ -1,0 +1,58 @@
+# Standby is an active-active status only
+
+`Standby` is reported in active-active clusters and never in active-passive. A node's own
+record of what it holds is no longer treated as privileged knowledge, because doing so let
+two members of one healthy cluster publish contradictory statuses for the same node at the
+same instant (END-2289): the elected node called itself `Standby` while its peer called it
+`Active`, and both were reading the same healthy cluster. The accepted cost is that `Active`
+now means different things in the two modes.
+
+## Why the old rule produced two answers
+
+`Standby` exists to split a question `Active` used to answer twice over — *is this daemon
+healthy and eligible* and *is it serving floating IPs*. Splitting it needs a count of what a
+member holds, and that count is only evidence where the list is knowledge: peers self-report
+their hosted addresses over `ConfigSync` in active-active and nowhere else, so in
+active-passive an empty list means "this node does not know", not "this node holds nothing".
+
+The original rule made one exception: a node's record of *itself* was authoritative in either
+mode. That exception is what came apart. In active-passive it made the only row that could
+ever read `Standby` the row you happened to be asking about, so the answer depended on which
+node you asked. A freshly paired appliance with no floating IPs configured reached it
+immediately — the elected node holds nothing, knows it holds nothing, and is the only observer
+allowed to conclude anything from that.
+
+A status an operator cannot compare between two nodes is not a status. That is the property
+being bought here, and it is worth more than the distinction being given up.
+
+## Considered options
+
+- **Gate on whether anything is configured to serve.** Keep the local-node exception, but only
+  derive `Standby` where the cluster has at least one floating IP. Fixes the reported symptom
+  and leaves the contradiction alive wherever groups *do* exist and an election-promoted node's
+  `ActiveIPs` is still empty — which is the `#1`/`#21` case, so it narrows the fix to the less
+  dangerous half.
+- **Derive the count from `config.Groups` instead of `ActiveIPs`.** Config is present on every
+  node, so this is viewer-independent *and* keeps `Standby` in active-passive. Rejected because
+  every node would then agree on `Standby` for a freshly paired cluster, which only helps once
+  consumers render `Standby` as healthy — and the client that ships in 3.3.0 does not
+  (END-2187). It remains the option to revisit if `Standby` is ever wanted in active-passive.
+- **Change nothing in the daemon and fix the clients.** Leaves the daemon answering a question
+  differently depending on who asks it. Every present and future consumer inherits that.
+
+## Consequences
+
+`Active` is mode-relative. In active-passive it means *elected*, and says nothing about whether
+the node is serving anything — the pre-`Standby` meaning. In active-active it means *serving at
+least one address*, with `Standby` covering healthy-and-eligible-but-serving-nothing. One wire
+value, two definitions, selected by a mode an operator can change at runtime. `CONTEXT.md`
+carries the definitions.
+
+Active-passive loses the ability to say "elected but serving nothing". That state is real, not
+hypothetical: on a cloud Platform, VIPs bind to Service IPs rather than floating IPs, so an
+elected node may legitimately hold none at all. It is now reported as `Active`, which is the
+answer its peers were already giving.
+
+Consumers must still handle `Standby` in either mode. The mode is runtime configuration, not a
+build-time fact, and active-active still emits the value — `lb_api`'s Azure active-state probe
+accepts both `ACTIVE` and `STANDBY` for exactly this reason and must keep doing so.

--- a/internal/membership/ip_monitor_release_test.go
+++ b/internal/membership/ip_monitor_release_test.go
@@ -142,9 +142,9 @@ func TestRemoveActiveIPsDropsOnlyTheGivenAddresses(t *testing.T) {
 }
 
 // A node that released everything must report an empty list, not a nil-vs-empty
-// distinction that reads as "no information" — deriveMemberStatus reports
-// Standby off an empty list, and that is the honest answer for a node serving
-// nothing.
+// distinction that reads as "no information" — in active-active
+// deriveMemberStatus reports Standby off an empty list, and that is the honest
+// answer for a node serving nothing.
 func TestRemoveActiveIPsCanEmptyTheList(t *testing.T) {
 	m := &Member{ActiveIPs: []string{"10.0.0.1/24", "10.0.0.2/24"}}
 

--- a/internal/server/member_status_test.go
+++ b/internal/server/member_status_test.go
@@ -1,9 +1,13 @@
 package server
 
 import (
+	"context"
+	"io"
 	"testing"
 
+	log "github.com/charmbracelet/log"
 	"github.com/syleron/pulseha/internal/membership"
+	"github.com/syleron/pulseha/packages/config"
 	"github.com/syleron/pulseha/rpc"
 )
 
@@ -13,78 +17,78 @@ import (
 // reported as Active, which told an operator nothing about whether traffic was
 // reaching it.
 //
-// The load-bearing case here is hasAssignmentTruth. An empty assignment list is
-// only evidence of holding nothing where the list is knowledge; on a peer in
+// The load-bearing case here is selfReportsAssignments. An empty assignment list
+// is only evidence of holding nothing where the list is knowledge; in
 // active-passive it means "this node does not know", and calling that Standby
 // would be worse than the vague Active it replaced.
 func TestDeriveMemberStatus(t *testing.T) {
 	tests := []struct {
-		name               string
-		status             membership.MemberStatus
-		assignedIPs        int
-		hasAssignmentTruth bool
-		want               rpc.MemberStatusEnum
+		name                   string
+		status                 membership.MemberStatus
+		assignedIPs            int
+		selfReportsAssignments bool
+		want                   rpc.MemberStatusEnum
 	}{
 		{
-			name:               "active holding nothing, list trustworthy, is Standby",
-			status:             membership.StatusActive,
-			assignedIPs:        0,
-			hasAssignmentTruth: true,
-			want:               rpc.MemberStatusEnum_MEMBER_STATUS_STANDBY,
+			name:                   "active holding nothing in active-active is Standby",
+			status:                 membership.StatusActive,
+			assignedIPs:            0,
+			selfReportsAssignments: true,
+			want:                   rpc.MemberStatusEnum_MEMBER_STATUS_STANDBY,
 		},
 		{
-			name:               "active holding addresses stays Active",
-			status:             membership.StatusActive,
-			assignedIPs:        61,
-			hasAssignmentTruth: true,
-			want:               rpc.MemberStatusEnum_MEMBER_STATUS_ACTIVE,
+			name:                   "active holding addresses stays Active",
+			status:                 membership.StatusActive,
+			assignedIPs:            61,
+			selfReportsAssignments: true,
+			want:                   rpc.MemberStatusEnum_MEMBER_STATUS_ACTIVE,
 		},
 		{
 			// The #1/#21 shape: an election-promoted node in active-passive
 			// holds every group address while its ActiveIPs is still empty, and
-			// peers get no self-report in that mode. Reporting Standby here
-			// would claim the node serving all the traffic is serving none.
-			name:               "active holding nothing without trustworthy list stays Active",
-			status:             membership.StatusActive,
-			assignedIPs:        0,
-			hasAssignmentTruth: false,
-			want:               rpc.MemberStatusEnum_MEMBER_STATUS_ACTIVE,
+			// nobody self-reports in that mode. Reporting Standby here would
+			// claim the node serving all the traffic is serving none.
+			name:                   "active holding nothing in active-passive stays Active",
+			status:                 membership.StatusActive,
+			assignedIPs:            0,
+			selfReportsAssignments: false,
+			want:                   rpc.MemberStatusEnum_MEMBER_STATUS_ACTIVE,
 		},
 		{
 			// Passive already means "holds nothing" in active-passive, so it is
 			// left alone: renaming it would churn the wire value every existing
 			// deployment reports without telling an operator anything new.
-			name:               "passive is unchanged even with a trustworthy empty list",
-			status:             membership.StatusPassive,
-			assignedIPs:        0,
-			hasAssignmentTruth: true,
-			want:               rpc.MemberStatusEnum_MEMBER_STATUS_PASSIVE,
+			name:                   "passive is unchanged even where the list is knowledge",
+			status:                 membership.StatusPassive,
+			assignedIPs:            0,
+			selfReportsAssignments: true,
+			want:                   rpc.MemberStatusEnum_MEMBER_STATUS_PASSIVE,
 		},
 		{
 			// Maintenance is a deliberate operator decision to exclude the node
 			// from promotion. Standby means "eligible", so it must not swallow
 			// Maintenance just because the node holds nothing.
-			name:               "maintenance outranks an empty assignment list",
-			status:             membership.StatusMaintenance,
-			assignedIPs:        0,
-			hasAssignmentTruth: true,
-			want:               rpc.MemberStatusEnum_MEMBER_STATUS_MAINTENANCE,
+			name:                   "maintenance outranks an empty assignment list",
+			status:                 membership.StatusMaintenance,
+			assignedIPs:            0,
+			selfReportsAssignments: true,
+			want:                   rpc.MemberStatusEnum_MEMBER_STATUS_MAINTENANCE,
 		},
 		{
-			name:               "unknown is a health fact and is never derived away",
-			status:             membership.StatusUnknown,
-			assignedIPs:        0,
-			hasAssignmentTruth: true,
-			want:               rpc.MemberStatusEnum_MEMBER_STATUS_UNKNOWN,
+			name:                   "unknown is a health fact and is never derived away",
+			status:                 membership.StatusUnknown,
+			assignedIPs:            0,
+			selfReportsAssignments: true,
+			want:                   rpc.MemberStatusEnum_MEMBER_STATUS_UNKNOWN,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := deriveMemberStatus(tt.status, tt.assignedIPs, tt.hasAssignmentTruth)
+			got := deriveMemberStatus(tt.status, tt.assignedIPs, tt.selfReportsAssignments)
 			if got != tt.want {
 				t.Errorf("deriveMemberStatus(%v, %d, %t) = %v, want %v",
-					membership.StatusToString(tt.status), tt.assignedIPs, tt.hasAssignmentTruth, got, tt.want)
+					membership.StatusToString(tt.status), tt.assignedIPs, tt.selfReportsAssignments, got, tt.want)
 			}
 		})
 	}
@@ -103,5 +107,121 @@ func TestStandbyIsNotAStoredMemberStatus(t *testing.T) {
 		if membership.StatusToString(s) == "Standby" {
 			t.Fatalf("Standby must be derived at the status boundary, not stored as MemberStatus(%d)", s)
 		}
+	}
+}
+
+// newStatusTestServer builds the minimum Server that GetClusterStatus needs: a
+// two-node config in the given mode, and a member list holding a healthy elected
+// node plus its passive peer.
+//
+// Pulse.LocalNode is deliberately populated and both nodes are present in Nodes,
+// so config.ClusterCheck passes and GetLocalNodeUUID would return the local ID.
+// The gate this pins used to consult exactly that, and a test where the local
+// node cannot be identified would pass whether the gate were reverted or not.
+func newStatusTestServer(t *testing.T, mode string, activeIPs []string) *Server {
+	t.Helper()
+
+	cfg := &config.Config{
+		Pulse: config.Local{Mode: mode, LocalNode: "node-a"},
+		Nodes: map[string]*config.Node{
+			"node-a": {Hostname: "node-a", IP: "10.0.0.1", Port: "9083"},
+			"node-b": {Hostname: "node-b", IP: "10.0.0.2", Port: "9083"},
+		},
+		Groups: map[string][]string{},
+	}
+
+	logger := log.New(io.Discard)
+	ml := membership.NewMemberList(cfg, logger)
+	for _, id := range []string{"node-a", "node-b"} {
+		if err := ml.AddMemberQuiet(id); err != nil {
+			t.Fatalf("AddMemberQuiet(%s): %v", id, err)
+		}
+	}
+
+	local := ml.GetMemberByID("node-a")
+	local.Status = membership.StatusActive
+	local.ActiveIPs = activeIPs
+
+	ml.GetMemberByID("node-b").Status = membership.StatusPassive
+
+	return &Server{config: cfg, logger: logger, memberList: ml}
+}
+
+func reportedStatus(t *testing.T, s *Server, nodeID string) rpc.MemberStatusEnum {
+	t.Helper()
+
+	resp, err := s.GetClusterStatus(context.Background(), &rpc.StatusRequest{})
+	if err != nil {
+		t.Fatalf("GetClusterStatus: %v", err)
+	}
+	for _, m := range resp.Members {
+		if m.NodeId == nodeID {
+			return m.Status
+		}
+	}
+	t.Fatalf("no member %s in the status response", nodeID)
+	return rpc.MemberStatusEnum_MEMBER_STATUS_UNKNOWN
+}
+
+// END-2289. deriveMemberStatus was correct in isolation and wrong at its only
+// call site, which had no test of any kind: the gate granted assignment truth to
+// selfReportsAssignments OR "this row is the local node", so in active-passive
+// the only row that could ever read Standby was the row you were asking about.
+// A healthy elected node holding nothing reported itself Standby while its peer
+// reported it Active — the same cluster, the same instant, two answers. On the
+// appliance that surfaced as one node showing "Standby / No Data" and cluster
+// health 1·1 against the other's 2·0.
+//
+// Both arms are asserted here because that is the whole point. Reverting the
+// gate expression leaves the active-active arm passing and only the
+// active-passive arm fails, and a fix whose two arms are not separately pinned
+// is one edit from being a no-op (docs/TEST-PLAN.md #67).
+func TestGetClusterStatusReportsStandbyOnlyInActiveActive(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+		want rpc.MemberStatusEnum
+	}{
+		{
+			// The reported defect. Nothing is configured to serve, so the
+			// elected node holds nothing and knows it holds nothing — and its
+			// peer, which cannot know, says Active. Active is the answer both
+			// have to give.
+			name: "active-passive elected node holding nothing is Active",
+			mode: "active-passive",
+			want: rpc.MemberStatusEnum_MEMBER_STATUS_ACTIVE,
+		},
+		{
+			// Standby keeps working where it means something: every member
+			// self-reports its hosted addresses in this mode, so every node
+			// computes the same answer for every row.
+			name: "active-active node holding nothing is Standby",
+			mode: "active-active",
+			want: rpc.MemberStatusEnum_MEMBER_STATUS_STANDBY,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newStatusTestServer(t, tt.mode, nil)
+			if got := reportedStatus(t, s, "node-a"); got != tt.want {
+				t.Errorf("node-a reported as %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The other half of the mode-relative meaning of Active: in active-active it
+// claims the node is serving something, so a node that holds addresses must not
+// be flattened into Standby just because Standby is available in that mode.
+func TestGetClusterStatusReportsActiveWhenHoldingAddresses(t *testing.T) {
+	for _, mode := range []string{"active-passive", "active-active"} {
+		t.Run(mode, func(t *testing.T) {
+			s := newStatusTestServer(t, mode, []string{"10.0.0.100/24"})
+			got := reportedStatus(t, s, "node-a")
+			if got != rpc.MemberStatusEnum_MEMBER_STATUS_ACTIVE {
+				t.Errorf("node-a reported as %v, want ACTIVE", got)
+			}
+		})
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1236,26 +1236,36 @@ func (s *Server) HandleNodeLeave(ctx context.Context, req *rpc.LeaveRequest) (*r
 // active-active existed. Standby separates them for display: healthy, eligible
 // for promotion, serving nothing.
 //
+// Standby is an active-active status and nothing else, which makes Active
+// mode-relative: in active-passive it means "elected", in active-active it means
+// "serving at least one address" (docs/adr/0001-standby-is-active-active-only.md).
+// The alternative was worse. This used to trust a node's record of itself in
+// either mode, so in active-passive the only row that could read Standby was the
+// row you happened to be asking about: a healthy elected node holding nothing
+// called itself Standby while its peer called it Active, and both were answering
+// from the same healthy cluster (END-2289). A status an operator cannot compare
+// between two nodes is not a status.
+//
 // Tenancy is derived here and nowhere else. It is not stored on the member, not
 // put on the wire between nodes, and not consulted by any placement or demotion
 // decision, because a stored copy would be the #1/#21 defect with a new name:
 // MakePassive returned success having released nothing, since ActiveIPs was
 // empty on a node that in fact held every address.
 //
-// hasAssignmentTruth is the reason this takes three arguments rather than two.
-// An empty assignment list only means "holds nothing" where the list is
+// selfReportsAssignments is the reason this takes three arguments rather than
+// two. An empty assignment list only means "holds nothing" where the list is
 // knowledge; elsewhere it means "this node does not know". Peers self-report
 // their hosted IPs over ConfigSync in active-active only (see the sender at the
-// buildFullConfigPayload self-report and its application in ConfigSync), so a
-// remote member's list is current in that mode. In active-passive there is no
-// self-report and a node promoted by election "holds them all while its
-// ActiveIPs is still empty" (internal/membership/health_check.go) — reporting
-// that node as Standby would be the most misleading answer available. A node's
-// record of itself is authoritative in either mode.
-func deriveMemberStatus(status membership.MemberStatus, assignedIPs int, hasAssignmentTruth bool) rpc.MemberStatusEnum {
+// buildFullConfigPayload self-report and its application in ConfigSync), so
+// every member's list is current in that mode and no member's list is in the
+// other. In active-passive there is no self-report and a node promoted by
+// election "holds them all while its ActiveIPs is still empty"
+// (internal/membership/health_check.go) — reporting that node as Standby would
+// be the most misleading answer available.
+func deriveMemberStatus(status membership.MemberStatus, assignedIPs int, selfReportsAssignments bool) rpc.MemberStatusEnum {
 	switch status {
 	case membership.StatusActive:
-		if assignedIPs == 0 && hasAssignmentTruth {
+		if assignedIPs == 0 && selfReportsAssignments {
 			return rpc.MemberStatusEnum_MEMBER_STATUS_STANDBY
 		}
 		return rpc.MemberStatusEnum_MEMBER_STATUS_ACTIVE
@@ -1273,20 +1283,15 @@ func (s *Server) GetClusterStatus(ctx context.Context, req *rpc.StatusRequest) (
 	s.RLock()
 	defer s.RUnlock()
 
-	// Resolved once rather than per member: IsLocal() re-reads the config and
-	// logs on every call, and this loop runs for every node in the cluster.
-	localID, _ := s.config.GetLocalNodeUUID()
+	// Read once rather than per member: this loop runs for every node in the
+	// cluster and the answer is the same for all of them.
 	selfReportsAssignments := s.config.Pulse.Mode == "active-active"
 
 	var members []*rpc.Member
 	membersSnapshot := s.memberList.MembersSnapshot()
 	for _, member := range membersSnapshot {
 		health := member.GetHealthStatus()
-		st := deriveMemberStatus(
-			health.Status,
-			len(health.ActiveIPs),
-			selfReportsAssignments || (localID != "" && member.ID == localID),
-		)
+		st := deriveMemberStatus(health.Status, len(health.ActiveIPs), selfReportsAssignments)
 
 		// Stamp a fresh last response for local display if empty/stale
 		lastResp := ""

--- a/rpc/server.proto
+++ b/rpc/server.proto
@@ -140,6 +140,14 @@ enum MemberStatusEnum {
     // placement decision. Reporting such a node as ACTIVE said nothing about
     // whether it was serving anything, which is what PARTIAL_ACTIVE (3, now
     // reserved) failed to fix by adding a stored value to this same enum.
+    //
+    // Reported in active-active clusters only, because that is the only mode
+    // where every member's assignment list is current — peers self-report their
+    // hosted addresses over ConfigSync there and nowhere else. In active-passive
+    // an empty list is absence of knowledge rather than evidence of holding
+    // nothing, so ACTIVE means "elected" and this value is never sent. A
+    // consumer must still handle it in either mode: the mode is runtime
+    // configuration, not a build-time fact.
     MEMBER_STATUS_STANDBY = 5;
 }
 

--- a/tests/integration/cluster_test.go
+++ b/tests/integration/cluster_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/syleron/pulseha/rpc"
 	"github.com/syleron/pulseha/tests/testutils"
 )
 
@@ -192,4 +193,65 @@ func TestActiveActiveMode(t *testing.T) {
 	// Verify that at least one node has active IPs
 	allActiveIPs := append(node1.GetActiveIPs(), node2.GetActiveIPs()...)
 	require.NotEmpty(t, allActiveIPs, "At least one node should have active IPs")
+}
+
+// END-2289. Two nodes in one healthy cluster published contradictory views of
+// that cluster at the same instant: asked on the elected node, its own row read
+// Standby; asked on its peer, the same node read Active. Nothing was wrong with
+// the cluster — the elected node held no addresses because none were configured,
+// and it was the only observer permitted to draw a conclusion from that.
+//
+// On the appliance the two views became "Standby / No Data" with cluster health
+// 1·1 on one node against "Active / Online" and 2·0 on the other.
+//
+// The generic agreement check at the end is the invariant, and it is deliberately
+// not spelled out as a pair of expected values: whatever a node publishes about
+// a member, every other node must publish the same thing, including values this
+// test was never taught to expect.
+func TestNodesAgreeOnTheStatusTheyPublish(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("integration tests run only on Linux")
+	}
+	os.Setenv("PULSEHA_TEST", "true")
+	defer os.Unsetenv("PULSEHA_TEST")
+
+	cluster := testutils.NewTestCluster()
+	defer cluster.Cleanup()
+
+	node1, err := cluster.AddNode("node1")
+	require.NoError(t, err, "Failed to add first node")
+	require.NoError(t, node1.Start(), "Failed to start first node")
+	require.NoError(t, cluster.WaitForPort("node1", 40), "node1 never accepted connections")
+
+	node2, err := cluster.AddNode("node2")
+	require.NoError(t, err, "Failed to add second node")
+	require.NoError(t, node2.Start(), "Failed to start second node")
+	require.NoError(t, cluster.WaitForPort("node2", 40), "node2 never accepted connections")
+
+	require.NoError(t, node2.Join(node1), "Failed to join second node to cluster")
+
+	// No groups are created anywhere in this test on purpose. A freshly paired
+	// appliance has no floating IPs, which is what made the elected node's
+	// assignment list empty and put it one branch away from Standby.
+	require.Equal(t, "active-passive", node1.Config.Pulse.Mode, "the default mode is the one under test")
+
+	// The defect, from the affected node's own point of view: elected, holding
+	// nothing, and nothing to hold. Active is the answer.
+	requireReportedStatus(t, node1, node1.Hostname, rpc.MemberStatusEnum_MEMBER_STATUS_ACTIVE,
+		"the elected node must not call itself Standby in active-passive")
+	requireReportedStatus(t, node2, node1.Hostname, rpc.MemberStatusEnum_MEMBER_STATUS_ACTIVE,
+		"the peer's view of the elected node was always correct and must stay so")
+	requireReportedStatus(t, node1, node2.Hostname, rpc.MemberStatusEnum_MEMBER_STATUS_PASSIVE,
+		"the passive node's row was always correct and must stay so")
+	requireReportedStatus(t, node2, node2.Hostname, rpc.MemberStatusEnum_MEMBER_STATUS_PASSIVE,
+		"the passive node must agree with its peer about itself")
+
+	for _, target := range []string{node1.Hostname, node2.Hostname} {
+		fromNode1, err := node1.ReportedStatus(target)
+		require.NoError(t, err, "node1 should report a status for %s", target)
+		fromNode2, err := node2.ReportedStatus(target)
+		require.NoError(t, err, "node2 should report a status for %s", target)
+		require.Equal(t, fromNode1, fromNode2,
+			"both nodes must publish the same status for %s", target)
+	}
 }

--- a/tests/integration/cluster_test.go
+++ b/tests/integration/cluster_test.go
@@ -220,11 +220,17 @@ func TestNodesAgreeOnTheStatusTheyPublish(t *testing.T) {
 
 	node1, err := cluster.AddNode("node1")
 	require.NoError(t, err, "Failed to add first node")
+	// Set explicitly rather than relying on a default: the harness writes no mode
+	// at all, and an empty mode only behaves like active-passive by accident of
+	// every gate testing for the other value. The appliance ships active-passive
+	// (packages/config/config.go), and that is the configuration under test.
+	node1.Config.Pulse.Mode = "active-passive"
 	require.NoError(t, node1.Start(), "Failed to start first node")
 	require.NoError(t, cluster.WaitForPort("node1", 40), "node1 never accepted connections")
 
 	node2, err := cluster.AddNode("node2")
 	require.NoError(t, err, "Failed to add second node")
+	node2.Config.Pulse.Mode = "active-passive"
 	require.NoError(t, node2.Start(), "Failed to start second node")
 	require.NoError(t, cluster.WaitForPort("node2", 40), "node2 never accepted connections")
 
@@ -233,7 +239,15 @@ func TestNodesAgreeOnTheStatusTheyPublish(t *testing.T) {
 	// No groups are created anywhere in this test on purpose. A freshly paired
 	// appliance has no floating IPs, which is what made the elected node's
 	// assignment list empty and put it one branch away from Standby.
-	require.Equal(t, "active-passive", node1.Config.Pulse.Mode, "the default mode is the one under test")
+	//
+	// Asked of the daemon rather than read off the config struct. The struct is
+	// what this test requested; only the daemon can say what it is acting on, and
+	// asserting the request would make the precondition self-referential.
+	for _, n := range []*testutils.TestNode{node1, node2} {
+		mode, err := n.ReportedMode()
+		require.NoError(t, err, "%s should report its cluster mode", n.Hostname)
+		require.Equal(t, "active-passive", mode, "%s must be running the mode under test", n.Hostname)
+	}
 
 	// The defect, from the affected node's own point of view: elected, holding
 	// nothing, and nothing to hold. Active is the answer.

--- a/tests/integration/wait_test.go
+++ b/tests/integration/wait_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/syleron/pulseha/rpc"
 	"github.com/syleron/pulseha/tests/testutils"
 )
 
@@ -38,5 +39,42 @@ func requireMemberStatus(t *testing.T, observer *testutils.TestNode, targetHostn
 	}
 
 	t.Fatalf("%s: %s's view of %s = %q after %s, want %q",
+		msg, observer.Hostname, targetHostname, got, statusSettleTimeout, want)
+}
+
+// requireReportedStatus waits for the status observer *publishes* for target to
+// reach want, and fails with the last value it actually saw.
+//
+// The sibling above reads the member list directly, which is a different
+// question: it sees what the daemon believes, not what it tells an operator.
+// Only this one crosses deriveMemberStatus, and END-2289 was a defect that lived
+// entirely on the far side of it.
+func requireReportedStatus(
+	t *testing.T,
+	observer *testutils.TestNode,
+	targetHostname string,
+	want rpc.MemberStatusEnum,
+	msg string,
+) {
+	t.Helper()
+
+	var (
+		got rpc.MemberStatusEnum
+		err error
+	)
+	deadline := time.Now().Add(statusSettleTimeout)
+	for time.Now().Before(deadline) {
+		got, err = observer.ReportedStatus(targetHostname)
+		if err == nil && got == want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if err != nil {
+		t.Fatalf("%s: %s could not report a status for %s within %s: %v",
+			msg, observer.Hostname, targetHostname, statusSettleTimeout, err)
+	}
+	t.Fatalf("%s: %s reports %s as %v after %s, want %v",
 		msg, observer.Hostname, targetHostname, got, statusSettleTimeout, want)
 }

--- a/tests/testutils/cluster.go
+++ b/tests/testutils/cluster.go
@@ -453,6 +453,42 @@ func (n *TestNode) GetMemberStatus(targetHostname string) string {
 	}
 }
 
+// ReportedStatus asks this node's daemon for the status it publishes for
+// targetHostname, through the same GetClusterStatus RPC the CLI and the
+// appliance's API call.
+//
+// GetMemberStatus above reads member.Status straight off the member list, which
+// skips deriveMemberStatus entirely — so every existing assertion in this suite
+// is blind to the whole status boundary, and END-2289 lived in that blind spot:
+// a healthy elected node published Standby about itself while its peer published
+// Active about the same node, and no test could see either value. Anything
+// asserting what an operator is told has to come through here.
+//
+// Returns the wire enum rather than a string so a value the harness has not been
+// taught about cannot be flattened into "unknown" and read as agreement.
+func (n *TestNode) ReportedStatus(targetHostname string) (rpc.MemberStatusEnum, error) {
+	c, err := n.callDaemon()
+	if err != nil {
+		return rpc.MemberStatusEnum_MEMBER_STATUS_UNKNOWN, err
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := c.CLI().Status(ctx, &rpc.StatusRequest{})
+	if err != nil {
+		return rpc.MemberStatusEnum_MEMBER_STATUS_UNKNOWN, fmt.Errorf("status RPC to %s: %v", n.Hostname, err)
+	}
+	for _, m := range resp.Members {
+		if m.Hostname == targetHostname {
+			return m.Status, nil
+		}
+	}
+	return rpc.MemberStatusEnum_MEMBER_STATUS_UNKNOWN,
+		fmt.Errorf("%s does not report a member named %s", n.Hostname, targetHostname)
+}
+
 // CreateGroup creates a new IP group
 // callDaemon dials this node's own daemon and hands the caller a connected
 // client.

--- a/tests/testutils/cluster.go
+++ b/tests/testutils/cluster.go
@@ -489,6 +489,29 @@ func (n *TestNode) ReportedStatus(targetHostname string) (rpc.MemberStatusEnum, 
 		fmt.Errorf("%s does not report a member named %s", n.Hostname, targetHostname)
 }
 
+// ReportedMode asks this node's daemon which cluster mode it is actually running
+// in, rather than reading the TestNode's own config struct.
+//
+// Not the same question. The struct is what the test asked for; this is what the
+// daemon is acting on, and END-2289 was entirely about the gap between a local
+// copy of a fact and the answer a daemon publishes.
+func (n *TestNode) ReportedMode() (string, error) {
+	c, err := n.callDaemon()
+	if err != nil {
+		return "", err
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := c.CLI().Status(ctx, &rpc.StatusRequest{})
+	if err != nil {
+		return "", fmt.Errorf("status RPC to %s: %v", n.Hostname, err)
+	}
+	return resp.Mode, nil
+}
+
 // CreateGroup creates a new IP group
 // callDaemon dials this node's own daemon and hands the caller a connected
 // client.


### PR DESCRIPTION
Fixes [END-2289](https://linear.app/loadbalancer/issue/END-2289/clustered-appliance-misreports-its-own-ha-status-as-standby-no-data).

## The defect

Not a rendering artefact. `GetClusterStatus` genuinely returned a different status for the same node depending on which node you asked.

`deriveMemberStatus` needs a trustworthy count of what a member holds before it can say `Standby` — *healthy, eligible, holding no floating IPs*. Peers self-report their hosted addresses over `ConfigSync` **in active-active only**, so in active-passive an empty list means "this node does not know" rather than "this node holds nothing". The old rule made one exception: a node's record of *itself* was authoritative in either mode.

That exception was the bug. In active-passive it made the only row that could ever read `Standby` the row you happened to be asking about:

| Asked on | Its view of the elected node |
| --- | --- |
| the elected node | `STANDBY` — own row, exempted, 0 addresses |
| its peer | `ACTIVE` — remote row, not exempted |

Same cluster, same instant. A freshly paired appliance reaches it immediately: no groups are configured, so the elected node holds nothing, knows it holds nothing, and is the only observer permitted to draw a conclusion from that. The peer was never wrong — it simply wasn't allowed to conclude anything.

On the appliance that surfaced as one node reporting "Standby / No Data" with cluster health `1·1` against its peer's "Active / Online" and `2·0`.

## The fix

`Standby` is reported in **active-active only** — the one mode where every member's assignment list is knowledge rather than the absence of it. The local-node exception is gone, so every node computes the same answer for every row. In active-passive, `Active` means *elected* and nothing else, which is what the peer was already reporting.

The parameter is renamed `hasAssignmentTruth` → `selfReportsAssignments`. It existed only to describe a member-level override of the mode; leaving that name in place is how the override gets reintroduced.

## The trade-off, recorded in ADR-0001

`Active` is now **mode-relative**: *elected* in active-passive, *serving at least one address* in active-active. One wire value, two definitions, selected by a mode an operator can change at runtime.

Active-passive gives up the "elected but serving nothing" distinction. That state is real, not hypothetical — on a cloud Platform, VIPs bind to Service IPs rather than floating IPs, so an elected node may legitimately hold none at all. It is now reported as `Active`, which is the answer its peers already gave.

Two alternatives were rejected, both written up in the ADR. The closest call: deriving the count from `config.Groups` rather than `ActiveIPs` would have been viewer-independent *and* kept `Standby` in active-passive, since config is present on every node — but every node would then agree on `Standby` for a freshly paired cluster, which only helps once consumers render `Standby` as healthy, and the 3.3.0 client does not ([END-2187](https://linear.app/loadbalancer/issue/END-2187/lb-client-replace-the-partialactive-node-state-with-pulseha-standby-on)).

## Tests

`deriveMemberStatus` was correct in isolation and wrong at its only call site — and that call site had **no coverage of any kind**. Reverting the gate killed nothing. The integration suite couldn't have caught it either: `requireMemberStatus` reads `member.Status` straight off the member list and never crosses the derivation boundary, so every existing assertion about node status was blind to the value an operator is actually shown.

- **`GetClusterStatus` unit test**, both modes pinned separately. **Mutation checked:** restoring the old gate expression fails the active-passive arm and only that arm. That is the `#67` property — a guard whose two arms are not separately pinned is one edit from being a no-op.
- **`TestNode.ReportedStatus`** asks the daemon through the same RPC the CLI and the appliance API use. Returns the wire enum rather than a string, so a value the harness hasn't been taught about can't be flattened into `unknown` and read as agreement.
- **`TestNodesAgreeOnTheStatusTheyPublish`** forms a pair, configures no groups on purpose, and asserts both nodes publish the same status for both members. The closing check is deliberately generic rather than a pair of expected values.

`requireMemberStatus` is left reading the field. Retrofitting it breaks `cluster_test.go`'s active-active self-assertion for a legitimate reason — a node given no addresses by placement really is `Standby` — and that question isn't this defect.

## Docs

- **`docs/adr/0001-standby-is-active-active-only.md`** — this repo's first ADR. It qualifies on all three counts: reversing it silently changes what `lb_api`'s Azure probe sees from a repo that doesn't import this one; the next reader will ask why a display helper is handed a count it may not trust for the local node, and the comment being replaced argued at length that it should; and a real alternative was rejected for specific reasons.
- **`CONTEXT.md`** — new glossary, scoped to node status. After this change the meaning of `Active` lived only in a Go doc comment and depends on a runtime-switchable mode. The `Standby` entry earns the file on its own: in ordinary HA English "standby" means the backup node, and here it means nearly the opposite, so an operator reading `Standby` beside `Passive` reads the spare exactly backwards.

## Verification

`go vet ./...` clean; unit suite green (`internal/...`, `packages/...`, `tests/unit/...`).

**The integration test has never executed.** `tests/integration` skips on non-Linux, so CI is its first real run. If it hangs for the full timeout rather than failing an assertion, that is `#79` — the partially-fixed startup deadlock between `Server.Start` and the first health-check pass, which shows up on loaded runners as `TestClusterFormation` hanging. This test forms a pair the same way.

## Not fixed here

- **`Standby` is still not one of the four documented node states**, because active-active still emits it. Correct behaviour, not a leftover.
- **The client half is [END-2187](https://linear.app/loadbalancer/issue/END-2187/lb-client-replace-the-partialactive-node-state-with-pulseha-standby-on).** Two paired appliances in active-active with no groups put *every* node in `Standby` legitimately, and the current client renders that as cluster health `0·2` with no promote button anywhere. This PR doesn't close that path — it stops the default mode reaching it.
- **[END-2292](https://linear.app/loadbalancer/issue/END-2292/lb-api-the-azure-active-state-probes-standby-justification-is-false)** — `lb_api`'s Azure probe keeps working (it accepts both `ACTIVE` and `STANDBY`, and must continue to), but its justification cites the exception this PR removes, and `ADR-0052` needs a decision on annotation vs superseding.
